### PR TITLE
Remove placeholders from subcaptions

### DIFF
--- a/manim_voiceover/voiceover_scene.py
+++ b/manim_voiceover/voiceover_scene.py
@@ -2,6 +2,7 @@ from math import ceil
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional, Generator
+import re
 
 from manim import Scene, config
 from manim_voiceover.services.base import SpeechService
@@ -70,7 +71,8 @@ class VoiceoverScene(Scene):
 
         if self.create_subcaption:
             if subcaption is None:
-                subcaption = text
+                # Remove placeholders
+                subcaption = re.sub(r"<[^<>]+/>", "", text)
 
             self.add_wrapped_subcaption(
                 subcaption,


### PR DESCRIPTION
Currently the subcaptions are emitted with placeholders. This PR add a RegEx replacement `re.sub(r"<[^<>]+/>", "", text)` to fix this behavior.