### PR TITLE
fix windows path to string bug

### DIFF
--- a/manim_voiceover/services/base.py
+++ b/manim_voiceover/services/base.py
@@ -110,8 +110,8 @@ class SpeechService(ABC):
             adjusted_path = split_path[0] + "_adjusted" + split_path[1]
 
             adjust_speed(
-                Path(self.cache_dir) / dict_["original_audio"],
-                Path(self.cache_dir) / adjusted_path,
+                str(Path(self.cache_dir) / dict_["original_audio"]),
+                str(Path(self.cache_dir) / adjusted_path),
                 self.global_speed,
             )
             dict_["final_audio"] = adjusted_path


### PR DESCRIPTION
In the modified line the Path was changed to a string. In Windows, without this added "str", the sox function throws an error for having a Path argument instead of an str argument (the exception is thrown in sox/core, line 51).