### PR TITLE
Replaced os.system with subprocess.run.

### DIFF
--- a/manim_voiceover/translate/gettext_utils.py
+++ b/manim_voiceover/translate/gettext_utils.py
@@ -2,6 +2,8 @@ import re
 import os
 import typing as t
 
+import subprocess
+
 from manim import logger
 
 from manim_voiceover.helper import prompt_ask_missing_extras
@@ -27,10 +29,10 @@ def init_gettext(files, domain, localedir):
         # Check if pot_path exists
         if os.path.exists(pot_path):
             # If it does, update it
-            os.system(f"xgettext -j -o {pot_path} {file}")
+            subprocess.run(["xgettext", "-j", "-o", pot_path, file])
         else:
             # If it does not, create it
-            os.system(f"xgettext -o {pot_path} {file}")
+            subprocess.run(["xgettext", "-o", pot_path, file])
 
 
 def init_language(target_lang, domain, localedir):
@@ -52,9 +54,7 @@ def init_language(target_lang, domain, localedir):
         pass
     else:
         # If it does not, create it
-        os.system(
-            f"msginit --no-translator -i {localedir / f'{domain}.pot'} -o {po_path} -l {target_lang}"
-        )
+        subprocess.run(["msginit", "--no-translator", "-i", localedir / f"{domain}.pot", "-o", po_path, "-l", target_lang])
 
     return po_path
 

--- a/manim_voiceover/translate/render.py
+++ b/manim_voiceover/translate/render.py
@@ -3,6 +3,8 @@ import os
 import sys
 from pathlib import Path
 
+import subprocess
+
 
 # Get the current working directory as Path
 CWD = Path.cwd()
@@ -108,15 +110,13 @@ def main():
         # If the .mo file does not exist, create it
         if not os.path.exists(mo_path):
             print(f"Creating {domain}.mo for {locale}")
-            os.system(f"msgfmt {po_path} -o {mo_path}")
+            subprocess.run(["msgfmt", po_path, "-o", mo_path])
 
         print(f"Rendering {scene} in {locale}...")
         # Set LOCALE environment variable to locale
         os.environ["LOCALE"] = locale
         ofile = scene + "_" + locale + ".mp4"
         cmd = [
-            f"LOCALE={locale}",
-            f"DOMAIN={domain}",
             "manim",
             f"-q{quality}",
             file,
@@ -128,7 +128,7 @@ def main():
 
         # Run manim with the command
         try:
-            result = os.system(" ".join(cmd))
+            result = subprocess.run(cmd, env={"LOCALE": locale, "DOMAIN": domain}).returncode
         except KeyboardInterrupt:
             print("KeyboardInterrupt")
             sys.exit(0)


### PR DESCRIPTION
`os.system` does not escape spaces in arguments (e.g., it thinks paths with spaces in them are two separate arguments), while `subprocess.run` does escape spaces in arguments, making it able to handle paths with spaces in them.