### PR TITLE
fix: Wayland pynput v1.7.7 workaround

### DIFF
--- a/manim_voiceover/services/recorder/utility.py
+++ b/manim_voiceover/services/recorder/utility.py
@@ -21,20 +21,20 @@ class MyListener(keyboard.Listener):
         self.key_pressed = None
 
     def on_press(self, key):
-        if not hasattr(key, "char"):
-            return True
-
-        if key.char == "r":
+        if hasattr(key, "r") or hasattr(key, "shift_r"):
             self.key_pressed = True
+        elif hasattr(key, "char"):
+            if key.char == "r" or key.char == "shift_r":
+                self.key_pressed = True
 
         return True
 
     def on_release(self, key):
-        if not hasattr(key, "char"):
-            return True
-
-        if key.char == "r":
+        if hasattr(key, "r") or hasattr(key, "shift_r"):
             self.key_pressed = False
+        elif hasattr(key, "char"):
+            if key.char == "r" or key.char == "shift_r":
+                self.key_pressed = False
 
         return True
 
@@ -92,7 +92,7 @@ class Recorder:
         self.listener = MyListener()
         self.listener.start()
 
-        print("Press and hold the 'r' key to begin recording")
+        print("Press and hold the 'r' (or Shift^R if on Wayland) key to begin recording")
         if self.first_call:
             print("Wait for 1 second, then start speaking.")
             print("Wait for at least 1 second after you finish speaking.")
@@ -103,7 +103,7 @@ class Recorder:
             )
             print("These instructions are only shown once.")
 
-        print("Release the 'r' key to end recording")
+        print("Release the 'r' (or Shift^R if on Wayland) key to end recording")
         self.task = sched.scheduler(time.time, time.sleep)
         self.event = self.task.enter(
             self.callback_delay, 1, self._record_task, ([path])


### PR DESCRIPTION
XWayland/Wayland does not reliably allow for capture of single key strokes via keyboard event listener(s), but playing about showed key-combos are _mostly_ caught quickly!

Also it seems on Arch Linux (I use Arch BTW™) the `key` object sent through the `keyboard.listener` has a different _shape_, or perhaps the inconsistencies in capture behaviors got me jumping to wrong-thinking.

Either way, these proposed changes _should_ preserve previously programmed `key.char` detection, while also allowing those stuck with Wayland to enjoy this tool.