### PR TITLE
Handled a blank input edge case during Recording and Updated Coqui to use newer managed fork of TTS instead of old unmanaged one

### DIFF
--- a/manim_voiceover/services/coqui.py
+++ b/manim_voiceover/services/coqui.py
@@ -7,10 +7,10 @@ from manim_voiceover.services.base import SpeechService
 try:
     from TTS.api import TTS
 except ImportError:
-    logger.error("Missing packages. Run `pip install TTS` to use CoquiService.")
+    logger.error("Missing packages. Run `pip install coqui-tts` to use CoquiService.")
 
 # DEFAULT_MODEL = TTS.list_models()[0]
-DEFAULT_MODEL = "tts_models/en/ljspeech/tacotron2-DDC"
+DEFAULT_MODEL = "tts_models/en/ljspeech/fast_pitch"
 
 
 class CoquiService(SpeechService):
@@ -48,7 +48,7 @@ class CoquiService(SpeechService):
         )
 
         self.init_kwargs = kwargs
-        prompt_ask_missing_package("TTS", "TTS>=0.13.3")
+        prompt_ask_missing_package("coqui-tts", "coqui-tts")
         SpeechService.__init__(self, **kwargs)
 
     def generate_from_text(

--- a/manim_voiceover/services/recorder/utility.py
+++ b/manim_voiceover/services/recorder/utility.py
@@ -249,7 +249,8 @@ class Recorder:
 """
             )
             try:
-                key = input()[-1].lower()
+                user_input = input().strip()
+                key = user_input[-1].lower() if user_input else "b"
                 if key == "l":
                     audio = AudioSegment.from_file(path)
                     play(audio)
@@ -260,6 +261,8 @@ class Recorder:
                     self._record(path)
                 elif key == "a":
                     break
+                elif key == "b":
+                    print("Blank input")
                 else:
                     print("Invalid input")
             except KeyboardInterrupt:


### PR DESCRIPTION
The recording fails with IndexError if you hit enter without typing a key (can happen to the best of us). Handled that blank input case. 

Updated coqui to prompt user to install newer managed fork for TTS instead of original unmaintained one.
https://pypi.org/project/coqui-tts/