### PR TITLE
fix: resolves pkg_resources deprecation

### DIFF
--- a/manim_voiceover/__init__.py
+++ b/manim_voiceover/__init__.py
@@ -1,6 +1,9 @@
+from importlib.metadata import version, PackageNotFoundError
+
 from manim_voiceover.tracker import VoiceoverTracker
 from manim_voiceover.voiceover_scene import VoiceoverScene
 
-import pkg_resources
-
-__version__: str = pkg_resources.get_distribution(__name__).version
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Overview: What does this pull request change?
Replaces usage of the deprecated `pkg_resources` module with `importlib.metadata` for accessing package metadata.

## Motivation and Explanation: Why and how do your changes improve the library?
`pkg_resources` is deprecated and throws an error unless explicitly installed. This PR updates the codebase to use `importlib.metadata`, which is part of the Python standard library (Python 3.8+) removing this dependency.

The change align with approach taken in the main `manim` (CE) library.

## Links to added or changed documentation pages

## Further Information and Comments
- Defaults to `__version__ = "0.0.0+unknown"` to be consistent with `manim`