### PR TITLE
fix: repair StitcherService

### DIFF
--- a/manim_voiceover/services/stitcher.py
+++ b/manim_voiceover/services/stitcher.py
@@ -83,8 +83,7 @@ def split_on_silence_modified(
     ]
 
 
-# Disable this for now
-class _StitcherService(SpeechService):
+class StitcherService(SpeechService):
     """Speech service for stitching audio recordings back onto a Manim scene"""
 
     def __init__(
@@ -147,7 +146,7 @@ class _StitcherService(SpeechService):
                 bitrate="256k",
                 format="mp3",
             )
-            output_dict["segments"].append({"index": i, "path": output_path})
+            output_dict["segments"].append({"index": i, "path": data_hash + ".mp3"})
 
         # Save output info
         with open(self.get_json_path(), "w") as f:


### PR DESCRIPTION
## Overview: What does this pull request change?
This PR repairs `StitcherService` by making two small changes in `manim_voiceover/services/stitcher.py`:

- Renames `_StitcherService` to `StitcherService` to make part of the publicly accessible API
- Fixes the segment metadata written to the output JSON so that each segment's `"path"` stores `data_hash + ".mp3"` rather than `output_path` (which currently results in a duplication `media\voiceovers\media\voiceovers`)

## Motivation and Explanation: Why and how do your changes improve the library?
The use of `StitcherService` is regularly requested by users on Discord as a way to use their own pre-recorded audio in their videos and is more robust that the `RecorderService`.

This bugfix makes the `StitcherService` usable as a service, without needing to explicitly specify a `cache_dir`.

## Links to added or changed documentation pages

## Further Information and Comments
Fix first diagnosed and suggested in #88.